### PR TITLE
Added Fixture and Test Metadata to report.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 lib
 node_modules
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,20 +1,15 @@
-# testcafe-reporter-json
-[![Build Status](https://travis-ci.org/DevExpress/testcafe-reporter-json.svg)](https://travis-ci.org/DevExpress/testcafe-reporter-json)
+# testcafe-reporter-json-complete
 
-This is the **JSON** reporter plugin for [TestCafe](http://devexpress.github.io/testcafe).
+This is a fork the **JSON** reporter plugin for [TestCafe](http://devexpress.github.io/testcafe).
 
-<p align="center">
-    <img src="https://raw.githubusercontent.com/DevExpress/testcafe-reporter-json/master/media/preview.png" alt="preview" />
-</p>
+This fork tries to proivde as much information as posible, while beeing compatible with the original testcafe-reporter-json.
+
+There will be come kind of redundancy.
 
 ## Install
 
-This reporter is shipped with TestCafe by default. In most cases, you won't need to install it separately.
-
-However, if you need to install this reporter, you can use the following command.
-
 ```
-npm install testcafe-reporter-json
+npm install testcafe-reporter-json-complete
 ```
 
 ## Usage
@@ -22,9 +17,8 @@ npm install testcafe-reporter-json
 When you run tests from the command line, specify the reporter name by using the `--reporter` option:
 
 ```
-testcafe chrome 'path/to/test/file.js' --reporter json
+testcafe chrome 'path/to/test/file.js' --reporter json-complete
 ```
-
 
 When you use API, pass the reporter name to the `reporter()` method:
 
@@ -33,9 +27,7 @@ testCafe
     .createRunner()
     .src('path/to/test/file.js')
     .browsers('chrome')
-    .reporter('json') // <-
+    .reporter('json-complete') // <-
     .run();
 ```
-
-## Author
-Developer Express Inc. (https://devexpress.com)
+Hauke Thorenz (https://github.com/htho/)

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "testcafe-reporter-json",
-  "version": "2.1.0",
-  "description": "JSON TestCafe reporter plugin.",
-  "repository": "https://github.com/DevExpress/testcafe-reporter-json",
+  "name": "testcafe-reporter-json-complete",
+  "version": "2.1.1",
+  "description": "JSON TestCafe reporter plugin (With all information available to the reporter).",
+  "repository": "https://github.com/htho/testcafe-reporter-json-complete",
   "author": {
-    "name": "Developer Express Inc.",
-    "url": "https://devexpress.com"
+    "name": "Hauke Thorenz",
+    "url": "https://github.com/htho/"
   },
   "main": "lib/index",
   "files": [

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,7 @@ export default function () {
                 meta,
                 errs,
 
+                errsRaw:        testRunInfo.errs,
                 durationMs:     testRunInfo.durationMs,
                 unstable:       testRunInfo.unstable,
                 screenshotPath: testRunInfo.screenshotPath,

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ export default function () {
         },
 
         reportFixtureStart (name, path, meta) {
-            this.currentFixture = { name, path, tests: [], meta };
+            this.currentFixture = { name, path, meta, tests: [] };
             this.report.fixtures.push(this.currentFixture);
         },
 
@@ -33,8 +33,8 @@ export default function () {
 
             this.currentFixture.tests.push({
                 name,
-                errs,
                 meta,
+                errs,
 
                 durationMs:     testRunInfo.durationMs,
                 unstable:       testRunInfo.unstable,

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,8 @@ export default function () {
             });
         },
 
-        reportTaskDone (endTime, passed, warnings) {
+        reportTaskDone (endTime, passed, warnings, result) {
+            this.report.result   = result;
             this.report.passed   = passed;
             this.report.endTime  = endTime;
             this.report.warnings = warnings;

--- a/src/index.js
+++ b/src/index.js
@@ -20,12 +20,12 @@ export default function () {
             this.report.total      = testCount;
         },
 
-        reportFixtureStart (name, path) {
-            this.currentFixture = { name, path, tests: [] };
+        reportFixtureStart (name, path, meta) {
+            this.currentFixture = { name, path, tests: [], meta };
             this.report.fixtures.push(this.currentFixture);
         },
 
-        reportTestDone (name, testRunInfo) {
+        reportTestDone (name, testRunInfo, meta) {
             var errs = testRunInfo.errs.map(err => this.formatError(err));
 
             if (testRunInfo.skipped)
@@ -34,6 +34,7 @@ export default function () {
             this.currentFixture.tests.push({
                 name,
                 errs,
+                meta,
 
                 durationMs:     testRunInfo.durationMs,
                 unstable:       testRunInfo.unstable,

--- a/test/data/report-with-colors
+++ b/test/data/report-with-colors
@@ -12,10 +12,19 @@
     {
       "name": "First fixture",
       "path": "./fixture1.js",
+      "meta": {
+        "fixtureMetaKey1": "fixtureMetaValue1",
+        "fixtureMetaKey2": "fixtureMetaValue2"
+      },
       "tests": [
         {
           "name": "First test in first fixture",
+          "meta": {
+            "testMetaKey1": "testMetaValue1",
+            "testMetaKey2": "testMetaValue2"
+          },
           "errs": [],
+          "errsRaw": [],
           "durationMs": 74000,
           "unstable": true,
           "screenshotPath": "/screenshots/1445437598847"
@@ -26,6 +35,181 @@
             "Error on page \"http://example.org\":\n\nSome error\n\nBrowser: Chrome 41.0.2227 / Mac OS X 10.10.1\nScreenshot: /screenshots/1445437598847/errors\n\n   1 |var createCallsiteRecord = require (some-file:1:1)\n   at Object.<anonymous> (some-file:1:1)\n   at Object.<anonymous> (some-file:1:1)",
             "The specified selector does not match any element in the DOM tree.\n\nBrowser: Firefox 47 / Mac OS X 10.10.1\n\n   1 |var createCallsiteRecord = require (some-file:1:1)\n   at Object.<anonymous> (some-file:1:1)\n   at Object.<anonymous> (some-file:1:1)"
           ],
+          "errsRaw": [
+            {
+              "TEMPLATES": {},
+              "userAgent": "Chrome 41.0.2227 / Mac OS X 10.10.1",
+              "screenshotPath": "/screenshots/1445437598847/errors",
+              "testRunState": "inTest",
+              "type": "uncaughtErrorOnPage",
+              "isTestCafeError": true,
+              "callsite": {
+                "filename": "C:\\TFS\\GitHub\\htho\\testcafe-reporter-json-complete\\test\\utils\\test-callsite.js",
+                "lineNum": 3,
+                "callsiteFrameIdx": 0,
+                "stackFrames": [
+                  {
+                    "functionName": "someFunc",
+                    "fileName": "C:\\TFS\\GitHub\\htho\\testcafe-reporter-json-complete\\test\\utils\\test-callsite.js",
+                    "lineNumber": 4,
+                    "columnNumber": 11,
+                    "source": "    at someFunc (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Object.<anonymous>",
+                    "fileName": "C:\\TFS\\GitHub\\htho\\testcafe-reporter-json-complete\\test\\utils\\test-callsite.js",
+                    "lineNumber": 8,
+                    "columnNumber": 5,
+                    "source": "    at Object.<anonymous> (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Module._compile",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 799,
+                    "columnNumber": 30,
+                    "source": "    at Module._compile (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Object.Module._extensions..js",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 810,
+                    "columnNumber": 10,
+                    "source": "    at Object.Module._extensions..js (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Module.load",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 666,
+                    "columnNumber": 32,
+                    "source": "    at Module.load (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "tryModuleLoad",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 606,
+                    "columnNumber": 12,
+                    "source": "    at tryModuleLoad (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Function.Module._load",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 598,
+                    "columnNumber": 3,
+                    "source": "    at Function.Module._load (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Module.require",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 705,
+                    "columnNumber": 19,
+                    "source": "    at Module.require (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "require",
+                    "fileName": "internal/modules/cjs/helpers.js",
+                    "lineNumber": 14,
+                    "columnNumber": 16,
+                    "source": "    at require (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Object.<anonymous>",
+                    "fileName": "C:\\TFS\\GitHub\\htho\\testcafe-reporter-json-complete\\test\\utils\\reporter-test-calls.js",
+                    "lineNumber": 4,
+                    "columnNumber": 38,
+                    "source": "    at Object.<anonymous> (some-file:1:1)"
+                  }
+                ],
+                "isV8Frames": false
+              },
+              "errMsg": "Some error",
+              "pageDestUrl": "http://example.org"
+            },
+            {
+              "TEMPLATES": {},
+              "userAgent": "Firefox 47 / Mac OS X 10.10.1",
+              "testRunState": "inTest",
+              "type": "actionElementNotFoundError",
+              "isTestCafeError": true,
+              "callsite": {
+                "filename": "C:\\TFS\\GitHub\\htho\\testcafe-reporter-json-complete\\test\\utils\\test-callsite.js",
+                "lineNum": 3,
+                "callsiteFrameIdx": 0,
+                "stackFrames": [
+                  {
+                    "functionName": "someFunc",
+                    "fileName": "C:\\TFS\\GitHub\\htho\\testcafe-reporter-json-complete\\test\\utils\\test-callsite.js",
+                    "lineNumber": 4,
+                    "columnNumber": 11,
+                    "source": "    at someFunc (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Object.<anonymous>",
+                    "fileName": "C:\\TFS\\GitHub\\htho\\testcafe-reporter-json-complete\\test\\utils\\test-callsite.js",
+                    "lineNumber": 8,
+                    "columnNumber": 5,
+                    "source": "    at Object.<anonymous> (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Module._compile",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 799,
+                    "columnNumber": 30,
+                    "source": "    at Module._compile (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Object.Module._extensions..js",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 810,
+                    "columnNumber": 10,
+                    "source": "    at Object.Module._extensions..js (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Module.load",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 666,
+                    "columnNumber": 32,
+                    "source": "    at Module.load (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "tryModuleLoad",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 606,
+                    "columnNumber": 12,
+                    "source": "    at tryModuleLoad (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Function.Module._load",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 598,
+                    "columnNumber": 3,
+                    "source": "    at Function.Module._load (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Module.require",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 705,
+                    "columnNumber": 19,
+                    "source": "    at Module.require (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "require",
+                    "fileName": "internal/modules/cjs/helpers.js",
+                    "lineNumber": 14,
+                    "columnNumber": 16,
+                    "source": "    at require (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Object.<anonymous>",
+                    "fileName": "C:\\TFS\\GitHub\\htho\\testcafe-reporter-json-complete\\test\\utils\\reporter-test-calls.js",
+                    "lineNumber": 4,
+                    "columnNumber": 38,
+                    "source": "    at Object.<anonymous> (some-file:1:1)"
+                  }
+                ],
+                "isV8Frames": false
+              }
+            }
+          ],
           "durationMs": 74000,
           "unstable": false,
           "screenshotPath": "/screenshots/1445437598847"
@@ -33,6 +217,7 @@
         {
           "name": "Third test in first fixture",
           "errs": [],
+          "errsRaw": [],
           "durationMs": 74000,
           "unstable": false,
           "screenshotPath": null
@@ -46,6 +231,7 @@
         {
           "name": "First test in second fixture",
           "errs": [],
+          "errsRaw": [],
           "durationMs": 74000,
           "unstable": false,
           "screenshotPath": null
@@ -53,6 +239,7 @@
         {
           "name": "Second test in second fixture",
           "errs": [],
+          "errsRaw": [],
           "durationMs": 74000,
           "unstable": false,
           "screenshotPath": null
@@ -60,6 +247,7 @@
         {
           "name": "Third test in second fixture",
           "errs": [],
+          "errsRaw": [],
           "durationMs": 0,
           "unstable": false,
           "screenshotPath": null,
@@ -75,6 +263,93 @@
           "name": "First test in third fixture",
           "errs": [
             "- Error in beforeEach hook -\nThe specified selector does not match any element in the DOM tree.\n\nBrowser: Firefox 47 / Mac OS X 10.10.1\n\n   1 |var createCallsiteRecord = require (some-file:1:1)\n   at Object.<anonymous> (some-file:1:1)\n   at Object.<anonymous> (some-file:1:1)"
+          ],
+          "errsRaw": [
+            {
+              "TEMPLATES": {},
+              "userAgent": "Firefox 47 / Mac OS X 10.10.1",
+              "testRunState": "inBeforeEach",
+              "type": "actionElementNotFoundError",
+              "isTestCafeError": true,
+              "callsite": {
+                "filename": "C:\\TFS\\GitHub\\htho\\testcafe-reporter-json-complete\\test\\utils\\test-callsite.js",
+                "lineNum": 3,
+                "callsiteFrameIdx": 0,
+                "stackFrames": [
+                  {
+                    "functionName": "someFunc",
+                    "fileName": "C:\\TFS\\GitHub\\htho\\testcafe-reporter-json-complete\\test\\utils\\test-callsite.js",
+                    "lineNumber": 4,
+                    "columnNumber": 11,
+                    "source": "    at someFunc (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Object.<anonymous>",
+                    "fileName": "C:\\TFS\\GitHub\\htho\\testcafe-reporter-json-complete\\test\\utils\\test-callsite.js",
+                    "lineNumber": 8,
+                    "columnNumber": 5,
+                    "source": "    at Object.<anonymous> (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Module._compile",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 799,
+                    "columnNumber": 30,
+                    "source": "    at Module._compile (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Object.Module._extensions..js",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 810,
+                    "columnNumber": 10,
+                    "source": "    at Object.Module._extensions..js (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Module.load",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 666,
+                    "columnNumber": 32,
+                    "source": "    at Module.load (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "tryModuleLoad",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 606,
+                    "columnNumber": 12,
+                    "source": "    at tryModuleLoad (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Function.Module._load",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 598,
+                    "columnNumber": 3,
+                    "source": "    at Function.Module._load (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Module.require",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 705,
+                    "columnNumber": 19,
+                    "source": "    at Module.require (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "require",
+                    "fileName": "internal/modules/cjs/helpers.js",
+                    "lineNumber": 14,
+                    "columnNumber": 16,
+                    "source": "    at require (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Object.<anonymous>",
+                    "fileName": "C:\\TFS\\GitHub\\htho\\testcafe-reporter-json-complete\\test\\utils\\reporter-test-calls.js",
+                    "lineNumber": 4,
+                    "columnNumber": 38,
+                    "source": "    at Object.<anonymous> (some-file:1:1)"
+                  }
+                ],
+                "isV8Frames": false
+              }
+            }
           ],
           "durationMs": 74000,
           "unstable": true,

--- a/test/data/report-with-colors
+++ b/test/data/report-with-colors
@@ -362,5 +362,10 @@
     "Was unable to take a screenshot due to an error.\n\nReferenceError: someVar is not defined",
     "Was unable to take a screenshot due to an error.\n\nReferenceError: someOtherVar is not defined",
     "Was unable to take screenshots because the screenshot directory is not specified. To specify it, use the \"-s\" or \"--screenshots\" command line option or the \"screenshots\" method of the test runner in case you are using API."
-  ]
+  ],
+  "result": {
+    "passedCount": 4,
+    "failedCount": 2,
+    "skippedCount": 1
+  }
 }

--- a/test/data/report-without-colors
+++ b/test/data/report-without-colors
@@ -12,10 +12,19 @@
     {
       "name": "First fixture",
       "path": "./fixture1.js",
+      "meta": {
+        "fixtureMetaKey1": "fixtureMetaValue1",
+        "fixtureMetaKey2": "fixtureMetaValue2"
+      },
       "tests": [
         {
           "name": "First test in first fixture",
+          "meta": {
+            "testMetaKey1": "testMetaValue1",
+            "testMetaKey2": "testMetaValue2"
+          },
           "errs": [],
+          "errsRaw": [],
           "durationMs": 74000,
           "unstable": true,
           "screenshotPath": "/screenshots/1445437598847"
@@ -26,6 +35,181 @@
             "Error on page \"http://example.org\":\n\nSome error\n\nBrowser: Chrome 41.0.2227 / Mac OS X 10.10.1\nScreenshot: /screenshots/1445437598847/errors\n\n   1 |var createCallsiteRecord = require (some-file:1:1)\n   at Object.<anonymous> (some-file:1:1)\n   at Object.<anonymous> (some-file:1:1)",
             "The specified selector does not match any element in the DOM tree.\n\nBrowser: Firefox 47 / Mac OS X 10.10.1\n\n   1 |var createCallsiteRecord = require (some-file:1:1)\n   at Object.<anonymous> (some-file:1:1)\n   at Object.<anonymous> (some-file:1:1)"
           ],
+          "errsRaw": [
+            {
+              "TEMPLATES": {},
+              "userAgent": "Chrome 41.0.2227 / Mac OS X 10.10.1",
+              "screenshotPath": "/screenshots/1445437598847/errors",
+              "testRunState": "inTest",
+              "type": "uncaughtErrorOnPage",
+              "isTestCafeError": true,
+              "callsite": {
+                "filename": "C:\\TFS\\GitHub\\htho\\testcafe-reporter-json-complete\\test\\utils\\test-callsite.js",
+                "lineNum": 3,
+                "callsiteFrameIdx": 0,
+                "stackFrames": [
+                  {
+                    "functionName": "someFunc",
+                    "fileName": "C:\\TFS\\GitHub\\htho\\testcafe-reporter-json-complete\\test\\utils\\test-callsite.js",
+                    "lineNumber": 4,
+                    "columnNumber": 11,
+                    "source": "    at someFunc (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Object.<anonymous>",
+                    "fileName": "C:\\TFS\\GitHub\\htho\\testcafe-reporter-json-complete\\test\\utils\\test-callsite.js",
+                    "lineNumber": 8,
+                    "columnNumber": 5,
+                    "source": "    at Object.<anonymous> (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Module._compile",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 799,
+                    "columnNumber": 30,
+                    "source": "    at Module._compile (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Object.Module._extensions..js",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 810,
+                    "columnNumber": 10,
+                    "source": "    at Object.Module._extensions..js (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Module.load",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 666,
+                    "columnNumber": 32,
+                    "source": "    at Module.load (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "tryModuleLoad",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 606,
+                    "columnNumber": 12,
+                    "source": "    at tryModuleLoad (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Function.Module._load",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 598,
+                    "columnNumber": 3,
+                    "source": "    at Function.Module._load (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Module.require",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 705,
+                    "columnNumber": 19,
+                    "source": "    at Module.require (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "require",
+                    "fileName": "internal/modules/cjs/helpers.js",
+                    "lineNumber": 14,
+                    "columnNumber": 16,
+                    "source": "    at require (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Object.<anonymous>",
+                    "fileName": "C:\\TFS\\GitHub\\htho\\testcafe-reporter-json-complete\\test\\utils\\reporter-test-calls.js",
+                    "lineNumber": 4,
+                    "columnNumber": 38,
+                    "source": "    at Object.<anonymous> (some-file:1:1)"
+                  }
+                ],
+                "isV8Frames": false
+              },
+              "errMsg": "Some error",
+              "pageDestUrl": "http://example.org"
+            },
+            {
+              "TEMPLATES": {},
+              "userAgent": "Firefox 47 / Mac OS X 10.10.1",
+              "testRunState": "inTest",
+              "type": "actionElementNotFoundError",
+              "isTestCafeError": true,
+              "callsite": {
+                "filename": "C:\\TFS\\GitHub\\htho\\testcafe-reporter-json-complete\\test\\utils\\test-callsite.js",
+                "lineNum": 3,
+                "callsiteFrameIdx": 0,
+                "stackFrames": [
+                  {
+                    "functionName": "someFunc",
+                    "fileName": "C:\\TFS\\GitHub\\htho\\testcafe-reporter-json-complete\\test\\utils\\test-callsite.js",
+                    "lineNumber": 4,
+                    "columnNumber": 11,
+                    "source": "    at someFunc (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Object.<anonymous>",
+                    "fileName": "C:\\TFS\\GitHub\\htho\\testcafe-reporter-json-complete\\test\\utils\\test-callsite.js",
+                    "lineNumber": 8,
+                    "columnNumber": 5,
+                    "source": "    at Object.<anonymous> (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Module._compile",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 799,
+                    "columnNumber": 30,
+                    "source": "    at Module._compile (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Object.Module._extensions..js",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 810,
+                    "columnNumber": 10,
+                    "source": "    at Object.Module._extensions..js (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Module.load",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 666,
+                    "columnNumber": 32,
+                    "source": "    at Module.load (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "tryModuleLoad",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 606,
+                    "columnNumber": 12,
+                    "source": "    at tryModuleLoad (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Function.Module._load",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 598,
+                    "columnNumber": 3,
+                    "source": "    at Function.Module._load (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Module.require",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 705,
+                    "columnNumber": 19,
+                    "source": "    at Module.require (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "require",
+                    "fileName": "internal/modules/cjs/helpers.js",
+                    "lineNumber": 14,
+                    "columnNumber": 16,
+                    "source": "    at require (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Object.<anonymous>",
+                    "fileName": "C:\\TFS\\GitHub\\htho\\testcafe-reporter-json-complete\\test\\utils\\reporter-test-calls.js",
+                    "lineNumber": 4,
+                    "columnNumber": 38,
+                    "source": "    at Object.<anonymous> (some-file:1:1)"
+                  }
+                ],
+                "isV8Frames": false
+              }
+            }
+          ],
           "durationMs": 74000,
           "unstable": false,
           "screenshotPath": "/screenshots/1445437598847"
@@ -33,6 +217,7 @@
         {
           "name": "Third test in first fixture",
           "errs": [],
+          "errsRaw": [],
           "durationMs": 74000,
           "unstable": false,
           "screenshotPath": null
@@ -46,6 +231,7 @@
         {
           "name": "First test in second fixture",
           "errs": [],
+          "errsRaw": [],
           "durationMs": 74000,
           "unstable": false,
           "screenshotPath": null
@@ -53,6 +239,7 @@
         {
           "name": "Second test in second fixture",
           "errs": [],
+          "errsRaw": [],
           "durationMs": 74000,
           "unstable": false,
           "screenshotPath": null
@@ -60,6 +247,7 @@
         {
           "name": "Third test in second fixture",
           "errs": [],
+          "errsRaw": [],
           "durationMs": 0,
           "unstable": false,
           "screenshotPath": null,
@@ -75,6 +263,93 @@
           "name": "First test in third fixture",
           "errs": [
             "- Error in beforeEach hook -\nThe specified selector does not match any element in the DOM tree.\n\nBrowser: Firefox 47 / Mac OS X 10.10.1\n\n   1 |var createCallsiteRecord = require (some-file:1:1)\n   at Object.<anonymous> (some-file:1:1)\n   at Object.<anonymous> (some-file:1:1)"
+          ],
+          "errsRaw": [
+            {
+              "TEMPLATES": {},
+              "userAgent": "Firefox 47 / Mac OS X 10.10.1",
+              "testRunState": "inBeforeEach",
+              "type": "actionElementNotFoundError",
+              "isTestCafeError": true,
+              "callsite": {
+                "filename": "C:\\TFS\\GitHub\\htho\\testcafe-reporter-json-complete\\test\\utils\\test-callsite.js",
+                "lineNum": 3,
+                "callsiteFrameIdx": 0,
+                "stackFrames": [
+                  {
+                    "functionName": "someFunc",
+                    "fileName": "C:\\TFS\\GitHub\\htho\\testcafe-reporter-json-complete\\test\\utils\\test-callsite.js",
+                    "lineNumber": 4,
+                    "columnNumber": 11,
+                    "source": "    at someFunc (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Object.<anonymous>",
+                    "fileName": "C:\\TFS\\GitHub\\htho\\testcafe-reporter-json-complete\\test\\utils\\test-callsite.js",
+                    "lineNumber": 8,
+                    "columnNumber": 5,
+                    "source": "    at Object.<anonymous> (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Module._compile",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 799,
+                    "columnNumber": 30,
+                    "source": "    at Module._compile (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Object.Module._extensions..js",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 810,
+                    "columnNumber": 10,
+                    "source": "    at Object.Module._extensions..js (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Module.load",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 666,
+                    "columnNumber": 32,
+                    "source": "    at Module.load (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "tryModuleLoad",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 606,
+                    "columnNumber": 12,
+                    "source": "    at tryModuleLoad (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Function.Module._load",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 598,
+                    "columnNumber": 3,
+                    "source": "    at Function.Module._load (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Module.require",
+                    "fileName": "internal/modules/cjs/loader.js",
+                    "lineNumber": 705,
+                    "columnNumber": 19,
+                    "source": "    at Module.require (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "require",
+                    "fileName": "internal/modules/cjs/helpers.js",
+                    "lineNumber": 14,
+                    "columnNumber": 16,
+                    "source": "    at require (some-file:1:1)"
+                  },
+                  {
+                    "functionName": "Object.<anonymous>",
+                    "fileName": "C:\\TFS\\GitHub\\htho\\testcafe-reporter-json-complete\\test\\utils\\reporter-test-calls.js",
+                    "lineNumber": 4,
+                    "columnNumber": 38,
+                    "source": "    at Object.<anonymous> (some-file:1:1)"
+                  }
+                ],
+                "isV8Frames": false
+              }
+            }
           ],
           "durationMs": 74000,
           "unstable": true,

--- a/test/data/report-without-colors
+++ b/test/data/report-without-colors
@@ -362,5 +362,10 @@
     "Was unable to take a screenshot due to an error.\n\nReferenceError: someVar is not defined",
     "Was unable to take a screenshot due to an error.\n\nReferenceError: someOtherVar is not defined",
     "Was unable to take screenshots because the screenshot directory is not specified. To specify it, use the \"-s\" or \"--screenshots\" command line option or the \"screenshots\" method of the test runner in case you are using API."
-  ]
+  ],
+  "result": {
+    "passedCount": 4,
+    "failedCount": 2,
+    "skippedCount": 1
+  }
 }

--- a/test/utils/reporter-test-calls.js
+++ b/test/utils/reporter-test-calls.js
@@ -174,7 +174,12 @@ module.exports = [
                 'Was unable to take screenshots because the screenshot directory is not specified. ' +
                 'To specify it, use the "-s" or "--screenshots" command line option or the ' +
                 '"screenshots" method of the test runner in case you are using API.'
-            ]
+            ],
+            {
+                passedCount:  4,
+                failedCount:  2,
+                skippedCount: 1
+            }
         ]
     }
 ];

--- a/test/utils/reporter-test-calls.js
+++ b/test/utils/reporter-test-calls.js
@@ -26,7 +26,8 @@ module.exports = [
         method: 'reportFixtureStart',
         args:   [
             'First fixture',
-            './fixture1.js'
+            './fixture1.js',
+            { fixtureMetaKey1: 'fixtureMetaValue1', fixtureMetaKey2: 'fixtureMetaValue2' }
         ]
     },
     {
@@ -38,7 +39,8 @@ module.exports = [
                 durationMs:     74000,
                 unstable:       true,
                 screenshotPath: '/screenshots/1445437598847'
-            }
+            },
+            { testMetaKey1: 'testMetaValue1', testMetaKey2: 'testMetaValue2' }
         ]
     },
     {


### PR DESCRIPTION
I want to see/accees as much information as possible in the json report.
The changes I made, make the metadata object from fixture and test available in the report.

The primary purpose of testcafe-reporter-json is to serve information in a machine readable way.
Adding more information/properties should not break any programs that work with the output of this reporter.

I'd be glad to answer any questions.